### PR TITLE
Enhance helm chart with default values and extra labels/annotations

### DIFF
--- a/deploy/cert-manager-webhook-abion/templates/apiservice.yaml
+++ b/deploy/cert-manager-webhook-abion/templates/apiservice.yaml
@@ -7,8 +7,14 @@ metadata:
     chart: {{ include "cert-manager-webhook-abion.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   annotations:
     cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "cert-manager-webhook-abion.servingCertificate" . }}"
+  {{- with .Values.additionalAnnotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   group: {{ .Values.groupName }}
   groupPriorityMinimum: 1000

--- a/deploy/cert-manager-webhook-abion/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-abion/templates/deployment.yaml
@@ -8,6 +8,13 @@ metadata:
     chart: {{ include "cert-manager-webhook-abion.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- with .Values.additionalLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -19,6 +26,13 @@ spec:
       labels:
         app: {{ include "cert-manager-webhook-abion.name" . }}
         release: {{ .Release.Name }}
+      {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "cert-manager-webhook-abion.fullname" . }}
       containers:

--- a/deploy/cert-manager-webhook-abion/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-abion/templates/deployment.yaml
@@ -35,6 +35,8 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "cert-manager-webhook-abion.fullname" . }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext  | indent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -65,6 +67,8 @@ spec:
             - name: certs
               mountPath: /tls
               readOnly: true
+          securityContext:
+{{ toYaml .Values.containerSecurityContext | indent 12 }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:

--- a/deploy/cert-manager-webhook-abion/templates/pki.yaml
+++ b/deploy/cert-manager-webhook-abion/templates/pki.yaml
@@ -11,6 +11,13 @@ metadata:
     chart: {{ include "cert-manager-webhook-abion.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selfSigned: {}
 
@@ -27,6 +34,13 @@ metadata:
     chart: {{ include "cert-manager-webhook-abion.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   secretName: {{ include "cert-manager-webhook-abion.rootCACertificate" . }}
   duration: 43800h # 5y
@@ -48,6 +62,13 @@ metadata:
     chart: {{ include "cert-manager-webhook-abion.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ca:
     secretName: {{ include "cert-manager-webhook-abion.rootCACertificate" . }}
@@ -65,6 +86,13 @@ metadata:
     chart: {{ include "cert-manager-webhook-abion.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   secretName: {{ include "cert-manager-webhook-abion.servingCertificate" . }}
   duration: 8760h # 1y

--- a/deploy/cert-manager-webhook-abion/templates/rbac.yaml
+++ b/deploy/cert-manager-webhook-abion/templates/rbac.yaml
@@ -8,6 +8,13 @@ metadata:
     chart: {{ include "cert-manager-webhook-abion.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 ---
 # Grant the webhook permission to read the ConfigMap containing the Kubernetes
 # apiserver's requestheader-ca-certificate
@@ -22,6 +29,13 @@ metadata:
     chart: {{ include "cert-manager-webhook-abion.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -43,6 +57,13 @@ metadata:
     chart: {{ include "cert-manager-webhook-abion.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -63,6 +84,13 @@ metadata:
     chart: {{ include "cert-manager-webhook-abion.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups:
       - {{ .Values.groupName }}
@@ -80,6 +108,13 @@ metadata:
     chart: {{ include "cert-manager-webhook-abion.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -95,6 +130,14 @@ kind: Role
 metadata:
   name: {{ include "cert-manager-webhook-abion.fullname" . }}:secret-reader
   namespace: {{ .Values.certManager.namespace | quote }}
+  {{- with .Values.additionalLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups:
       - ""
@@ -111,6 +154,14 @@ kind: RoleBinding
 metadata:
   name: {{ include "cert-manager-webhook-abion.fullname" . }}:secret-reader
   namespace: {{ .Values.certManager.namespace | quote }}
+  {{- with .Values.additionalLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -134,6 +185,13 @@ metadata:
     chart: {{ include "cert-manager-webhook-abion.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups:
       - "flowcontrol.apiserver.k8s.io"
@@ -153,6 +211,13 @@ metadata:
     chart: {{ include "cert-manager-webhook-abion.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/cert-manager-webhook-abion/templates/service.yaml
+++ b/deploy/cert-manager-webhook-abion/templates/service.yaml
@@ -8,6 +8,13 @@ metadata:
     chart: {{ include "cert-manager-webhook-abion.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/deploy/cert-manager-webhook-abion/values.yaml
+++ b/deploy/cert-manager-webhook-abion/values.yaml
@@ -37,8 +37,29 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
+# Replica count for deployment
+replicaCount: 1
+
+# Log level for deployment
+logLevel: info
+
 nodeSelector: {}
 
 tolerations: []
 
 affinity: {}
+
+# Extra labels for all resources
+additionalLabels: {}
+
+# Extra annotations for all resources
+additionalAnnotations: {}
+
+# Extra annotations for pods in deployment
+podAnnotations: {}
+
+# Extra labels for pods in deployment
+podLabels: {}
+
+features:
+  apiPriorityAndFairness: true # Must be removed or set to `false` for Kubernetes older than 1.20.*

--- a/deploy/cert-manager-webhook-abion/values.yaml
+++ b/deploy/cert-manager-webhook-abion/values.yaml
@@ -61,5 +61,11 @@ podAnnotations: {}
 # Extra labels for pods in deployment
 podLabels: {}
 
+# Security context for pod
+podSecurityContext: {}
+
+# Security context for container
+containerSecurityContext: {}
+
 features:
   apiPriorityAndFairness: true # Must be removed or set to `false` for Kubernetes older than 1.20.*


### PR DESCRIPTION
Added additional annotations/labels, useful for gitops such as ArgoCD
Added extra annotations/labels for pods created by deployment
Updated values.yaml to set default values to avoid confusion.
Added capability to configure securitycontext 